### PR TITLE
cmd/fs fixing package dependency chain

### DIFF
--- a/cmd/fs_mgmt/port/mynewt/pkg.yml
+++ b/cmd/fs_mgmt/port/mynewt/pkg.yml
@@ -1,0 +1,27 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+pkg.name: cmd/fs_mgmt/port/mynewt
+pkg.description: 'File system command handlers for mcumgr.'
+pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
+pkg.homepage: "http://mynewt.apache.org/"
+pkg.keywords:
+
+pkg.deps:
+    - '@apache-mynewt-mcumgr/cmd/fs'


### PR DESCRIPTION
cmd/ dependencies are usually included by mynewt via cmd/feature/port/mynewt, see img_mgmt. This commit just makes fs_mgmt work the same way.